### PR TITLE
Export HydroChrono for inclusion in other cmake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,3 +174,38 @@ endif(HYDROCHRONO_ENABLE_TESTS)
 # dosen't work on Linux
 #set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 #add_DLL_copy_command("${CHRONO_DLLS}")
+
+
+# Export to include as external library in other projects
+
+install(TARGETS HydroChrono
+    EXPORT HydroChronoTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(
+    EXPORT HydroChronoTargets
+    FILE HydroChronoTargets.cmake
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/HydroChrono/cmake"
+    NAMESPACE HydroChrono::
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    cmake/HydroChronoConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/HydroChronoConfig.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_DATADIR}/HydroChrono/cmake"
+)
+
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/HydroChronoConfig.cmake"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/HydroChrono/cmake"
+)
+
+export(
+    EXPORT HydroChronoTargets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/HydroChronoTargets.cmake"
+    NAMESPACE HydroChrono::
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ endif(HYDROCHRONO_ENABLE_TESTS)
 #set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 #add_DLL_copy_command("${CHRONO_DLLS}")
 
+include(GNUInstallDirs)
 
 # Export to include as external library in other projects
 
@@ -183,6 +184,7 @@ install(TARGETS HydroChrono
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 install(
@@ -190,6 +192,11 @@ install(
     FILE HydroChronoTargets.cmake
     DESTINATION "${CMAKE_INSTALL_DATADIR}/HydroChrono/cmake"
     NAMESPACE HydroChrono::
+)
+
+install(
+    DIRECTORY include
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 include(CMakePackageConfigHelpers)

--- a/cmake/HydroChronoConfig.cmake.in
+++ b/cmake/HydroChronoConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(HDF5)
+find_dependency(Chrono)
+
+include("${CMAKE_CURRENT_LIST_DIR}/HydroChronoTargets.cmake")


### PR DESCRIPTION
This PR is for including HydroChrono more easily in other projects depending on it through `find_packages` by making a `cmake` folder in the `build` directory.
It has been tested locally in another project using `find_package(HydroChrono REQUIRED)` and it ensures that dependencies of HydroChrono are also found (such as Chrono and HDF5).