### PR TITLE
Mpa/ui3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,57 @@ target_link_libraries(HydroChrono
 
 )
 
+# ====================
+# Irrlicht GUI helper
+# ====================
+if(HYDROCHRONO_ENABLE_IRRLICHT)
+
+	add_library(HydroChronoGUI)
+
+	target_sources(
+		HydroChronoGUI
+
+		PUBLIC
+		src/gui/guihelper.cpp
+	)
+
+	target_compile_features(HydroChronoGUI PUBLIC cxx_std_17)
+
+
+	target_include_directories(
+		HydroChronoGUI
+
+		PUBLIC
+		
+		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+		$<INSTALL_INTERFACE:include>
+		${CHRONO_INCLUDE_DIRS} 		
+	)
+
+	target_compile_definitions(HydroChronoGUI
+		PUBLIC
+			CHRONO_DATA_DIR=\"${CHRONO_DATA_DIR}\"
+		PRIVATE
+			HYDROCHRONO_HAVE_IRRLICHT=1			
+	)
+
+	target_compile_options(HydroChronoGUI BEFORE 
+		PUBLIC
+			${CHRONO_CXX_FLAGS}
+	)
+
+	target_link_options(HydroChronoGUI BEFORE 
+		PUBLIC
+			${CHRONO_LINKER_FLAGS}
+	)
+
+	target_link_libraries(HydroChronoGUI 
+		PRIVATE
+			${CHRONO_LIBRARIES}
+	)
+
+
+endif(HYDROCHRONO_ENABLE_IRRLICHT)
 
 # ====================
 # DEMOS

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -163,6 +163,7 @@ target_include_directories(
 
 target_link_libraries(oswec_decay
     PRIVATE
+	HydroChronoGUI
     HydroChrono
 )
 

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -24,7 +24,13 @@ target_include_directories(
 	    ${CMAKE_CURRENT_SOURCE_DIR}/
 	    ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
-target_link_libraries(sphere_decay HydroChrono)
+
+target_link_libraries(sphere_decay 
+	PRIVATE
+	HydroChronoGUI
+	HydroChrono
+	
+)
 
 
 # =====================

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -61,6 +61,7 @@ target_include_directories(
 )
 target_link_libraries(sphere_reg_waves 
     PRIVATE 
+	HydroChronoGUI	
     HydroChrono
 )
 

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -197,5 +197,6 @@ target_include_directories(
 
 target_link_libraries(f3of
     PRIVATE
+	HydroChronoGUI	
     HydroChrono
 )

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -95,6 +95,7 @@ target_include_directories(
 
 target_link_libraries(rm3_decay
     PRIVATE 
+	HydroChronoGUI	
     HydroChrono
 )
 
@@ -127,7 +128,8 @@ target_include_directories(
 )
 
 target_link_libraries(rm3_reg_waves 
-    PRIVATE 
+    PRIVATE
+	HydroChronoGUI	
     HydroChrono
 )
 

--- a/demos/f3of/F3OF.cpp
+++ b/demos/f3of/F3OF.cpp
@@ -1,22 +1,10 @@
 #include <hydroc/hydro_forces.h>
-
 #include <hydroc/helper.h>
-
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-    #include <chrono_irrlicht/ChVisualSystemIrrlicht.h>
-    #include <chrono_irrlicht/ChIrrMeshTools.h>
-    // Use the main namespaces of Irrlicht
-    using namespace irr;
-    using namespace irr::core;
-    using namespace irr::scene;
-    using namespace irr::video;
-    using namespace irr::io;
-    using namespace irr::gui;
-    using namespace chrono::irrlicht;
-#endif
+#include <hydroc/gui/guihelper.h>
 
 #include <chrono/core/ChRealtimeStep.h>
 #include <chrono/physics/ChLinkMate.h>
+
 #include <iomanip> // std::setprecision
 #include <chrono> // std::chrono::high_resolution_clock::now
 #include <vector> // std::vector<double>
@@ -26,60 +14,26 @@ using namespace chrono;
 using namespace chrono::geometry;
 
 
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-// Define a class to manage user inputs via the GUI (i.e. play/pause button)
-class MyActionReceiver : public IEventReceiver {
-public:
-	MyActionReceiver(ChVisualSystemIrrlicht* vsys, bool& buttonPressed)
-		: pressed(buttonPressed) {
-		// store pointer application
-		vis = vsys;
-
-		// ..add a GUI button to control pause/play
-		pauseButton = vis->GetGUIEnvironment()->addButton(rect<s32>(510, 20, 650, 35));
-		buttonText = vis->GetGUIEnvironment()->addStaticText(L"Paused", rect<s32>(560, 20, 600, 35), false);
-	}
-
-	bool OnEvent(const SEvent& event) {
-		// check if user clicked button
-		if (event.EventType == EET_GUI_EVENT) {
-			switch (event.GUIEvent.EventType) {
-			case EGET_BUTTON_CLICKED:
-				pressed = !pressed;
-				if (pressed) {
-					buttonText->setText(L"Playing");
-				}
-				else {
-					buttonText->setText(L"Paused");
-				}
-				return pressed;
-				break;
-			default:
-				break;
-			}
-		}
-		return false;
-	}
-
-private:
-	ChVisualSystemIrrlicht* vis;
-	IGUIButton* pauseButton;
-	IGUIStaticText* buttonText;
-
-	bool& pressed;
-};
-#endif
-
-
+// usage: ./<demos>.exe [DATADIR] [--nogui]
+//
+// If no argument is given user can set HYDROCHRONO_DATA_DIR 
+// environment variable to give the data_directory.
+// 
 int main(int argc, char* argv[]) {
-	//auto start = std::chrono::high_resolution_clock::now();
-	GetLog() << "Chrono version: " << CHRONO_VERSION << "\n\n";
 
+	GetLog() << "Chrono version: " << CHRONO_VERSION << "\n\n";
 
 	if (hydroc::setInitialEnvironment(argc, argv) != 0) {
 		return 1;
 	}
 
+	// Check if --nogui option is set as 2nd argument
+	bool visualizationOn = true;
+	if(argc > 2 &&  std::string("--nogui").compare(argv[2]) == 0)  {
+		visualizationOn = false;
+	}
+
+	// Get model file names
 	std::filesystem::path DATADIR(hydroc::getDataDir());
 
 	auto body1_meshfame = (DATADIR / "f3of" / "geometry" / "base.obj")
@@ -97,6 +51,7 @@ int main(int argc, char* argv[]) {
 
 	// system/solver settings
 	ChSystemSMC system;
+
 	system.Set_G_acc(ChVector<>(0.0, 0.0, -9.81));
 	double timestep = 0.02;
 	system.SetSolverType(ChSolver::Type::SPARSE_QR);
@@ -105,8 +60,11 @@ int main(int argc, char* argv[]) {
 	ChRealtimeStepTimer realtime_timer;
 	double simulationDuration = 300.0;
 
+	// Create user interface
+	std::shared_ptr<hydroc::gui::UI> pui = hydroc::gui::CreateUI(visualizationOn);
+	hydroc::gui::UI& ui = *pui.get();
+
 	// some io/viz options
-	bool visualizationOn = true;
 	bool profilingOn = true;
 	bool saveDataOn = true;
 	std::vector<double> time_vector;
@@ -126,6 +84,18 @@ int main(int argc, char* argv[]) {
 		false                                                                                     // collisions
 		);
 
+	// Create a visualization material
+	auto red = chrono_types::make_shared<ChVisualMaterial>();
+	red->SetDiffuseColor(ChColor(0.3f, 0.1f, 0.1f));
+	base->GetVisualShape(0)->SetMaterial(0, red);
+
+	// define the base's initial conditions (position and rotation defined later for specific test)
+	system.Add(base);
+	base->SetNameString("body1");
+	base->SetMass(1089825.0);
+	base->SetInertiaXX(ChVector<>(100000000.0, 76300000.0, 100000000.0));
+
+
 	std::cout << "Attempting to open mesh file: " << body2_meshfame << std::endl;
 	std::shared_ptr<ChBody> flapFore = chrono_types::make_shared<ChBodyEasyMesh>(                   //
 		body2_meshfame,
@@ -135,6 +105,18 @@ int main(int argc, char* argv[]) {
 		false                                                                                     // collisions
 		);
 
+	// Create a visualization material
+	auto blue = chrono_types::make_shared<ChVisualMaterial>();
+	blue->SetDiffuseColor(ChColor(0.3f, 0.1f, 0.6f));
+	flapFore->GetVisualShape(0)->SetMaterial(0, blue);
+
+	// define the fore flap's initial conditions (position and rotation defined later for specific tests
+	system.Add(flapFore);
+	flapFore->SetNameString("body2");
+	flapFore->SetMass(179250.0);
+	flapFore->SetInertiaXX(ChVector<>(100000000.0, 1300000.0, 100000000.0));
+
+
 	std::cout << "Attempting to open mesh file: " << body3_meshfame << std::endl;
 	std::shared_ptr<ChBody> flapAft = chrono_types::make_shared<ChBodyEasyMesh>(                   //
 		body3_meshfame,
@@ -143,23 +125,19 @@ int main(int argc, char* argv[]) {
 		true,                                                                                     // create visualization asset
 		false                                                                                     // collisions
 		);
-	// define the base's initial conditions (position and rotation defined later for specific test)
-	system.Add(base);
-	base->SetNameString("body1");
-	base->SetMass(1089825.0);
-	base->SetInertiaXX(ChVector<>(100000000.0, 76300000.0, 100000000.0));
 
-	// define the fore flap's initial conditions (position and rotation defined later for specific tests
-	system.Add(flapFore);
-	flapFore->SetNameString("body2");
-	flapFore->SetMass(179250.0);
-	flapFore->SetInertiaXX(ChVector<>(100000000.0, 1300000.0, 100000000.0));
+	// Create a visualization material
+	auto green = chrono_types::make_shared<ChVisualMaterial>();
+	green->SetDiffuseColor(ChColor(0.3f, 0.6f, 0.1f));
+	flapAft->GetVisualShape(0)->SetMaterial(0, green);
 
 	// define the aft flap's initial conditions (position and rotation defined later for specific tests
 	system.Add(flapAft);
 	flapAft->SetNameString("body3");
 	flapAft->SetMass(179250.0);
 	flapAft->SetInertiaXX(ChVector<>(100000000.0, 1300000.0, 100000000.0));
+
+
 
 	// ---------------- Begin specific DT set up, comment out unused tests ----------------------------
 	// ---------------- DT1 set up (surge decay, flaps locked, no waves) ------------------------------
@@ -280,67 +258,24 @@ int main(int argc, char* argv[]) {
 	// for profiling
 	auto start = std::chrono::high_resolution_clock::now();
 
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-	if (visualizationOn) {
-		// create the irrlicht application for visualizing
-		auto irrlichtVis = chrono_types::make_shared<ChVisualSystemIrrlicht>();
-		irrlichtVis->AttachSystem(&system);
-		irrlichtVis->SetWindowSize(1280, 720);
-		irrlichtVis->SetWindowTitle("F3OF - Decay Test");
-		irrlichtVis->SetCameraVertical(CameraVerticalDir::Z);
-		irrlichtVis->Initialize();
-		irrlichtVis->AddLogo();
-		irrlichtVis->AddSkyBox();
-		irrlichtVis->AddCamera(ChVector<>(0, -50, -10), ChVector<>(0, 0, -10)); // camera position and where it points
-		irrlichtVis->AddTypicalLights();
-		//irrlichtVis->EnableBodyFrameDrawing(true);
-		//irrlichtVis->EnableLinkFrameDrawing(true);
+	// main simulation loop
+	ui.Init(&system, "F3OF - Decay Test");
+	ui.SetCamera(0, -50, -10, 0, 0, -10);
 
-		// add play/pause button
-		bool buttonPressed = false;
-		MyActionReceiver receiver(irrlichtVis.get(), buttonPressed);
-		irrlichtVis->AddUserEventReceiver(&receiver);
-		//ChSparseMatrix M;
-		// main simulation loop
-		while (irrlichtVis->Run() && system.GetChTime() <= simulationDuration) {
-			irrlichtVis->BeginScene();
-			irrlichtVis->Render();
-			irrlichtVis->EndScene();
-			if (buttonPressed) {
-				//system.GetMassMatrix(&M);
-				//std::cout << M << std::endl;
-				// step the simulation forwards
-				system.DoStepDynamics(timestep);
-				// append data to std vector
-				time_vector.push_back(system.GetChTime());
-				base_surge.push_back(base->GetPos().x());
-				base_pitch.push_back(base->GetRot().Q_to_Euler123().y());
-				fore_pitch.push_back(flapFore->GetRot().Q_to_Euler123().y());
-				aft_pitch.push_back(flapAft->GetRot().Q_to_Euler123().y());
-				// force playback to be real-time
-				realtime_timer.Spin(timestep);
+	while (system.GetChTime() <= simulationDuration) {
 
-			}
-		}
-	}
-	else {
-#endif // #ifdef HYDROCHRONO_HAVE_IRRLICHT
-		int frame = 0;
-		while (system.GetChTime() <= simulationDuration) {
-			// append data to std vector
-			time_vector.push_back(system.GetChTime());
+		if(ui.IsRunning(timestep) == false) break;
+		
+		if (ui.simulationStarted) {
+
+			// append data to output vector
+			time_vector.push_back(system.GetChTime());			
 			base_surge.push_back(base->GetPos().x());
 			base_pitch.push_back(base->GetRot().Q_to_Euler123().y());
 			fore_pitch.push_back(flapFore->GetRot().Q_to_Euler123().y());
-			aft_pitch.push_back(flapAft->GetRot().Q_to_Euler123().y());
-			// step the simulation forwards
-			system.DoStepDynamics(timestep);
-
-			frame++;
+			aft_pitch.push_back(flapAft->GetRot().Q_to_Euler123().y());		
 		}
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
 	}
-#endif
 
 	if (saveDataOn) {
 		std::ofstream outputFile;
@@ -373,5 +308,7 @@ int main(int argc, char* argv[]) {
 			<< std::endl;
 		outputFile.close();
 	}
+
+	std::cout << "Simulation finished." << std::endl;	
 	return 0;
 }

--- a/demos/oswec/oswec_decay.cpp
+++ b/demos/oswec/oswec_decay.cpp
@@ -1,11 +1,9 @@
 #include <hydroc/hydro_forces.h>
-
 #include <hydroc/helper.h>
-//#include "./src/hydro_forces.h"
-#include "chrono_irrlicht/ChVisualSystemIrrlicht.h"
-#include "chrono_irrlicht/ChIrrMeshTools.h"
-#include "chrono/core/ChRealtimeStep.h"
-#include "chrono/physics/ChLinkMate.h"
+#include <hydroc/gui/guihelper.h>
+
+#include <chrono/core/ChRealtimeStep.h>
+
 #include <iomanip> // std::setprecision
 #include <chrono> // std::chrono::high_resolution_clock::now
 #include <vector> // std::vector<double>
@@ -13,66 +11,27 @@
 // Use the namespaces of Chrono
 using namespace chrono;
 using namespace chrono::geometry;
-using namespace chrono::irrlicht;
 
-// Use the main namespaces of Irrlicht
-using namespace irr;
-using namespace irr::core;
-using namespace irr::scene;
-using namespace irr::video;
-using namespace irr::io;
-using namespace irr::gui;
-
-class MyActionReceiver : public IEventReceiver {
-public:
-	MyActionReceiver(ChVisualSystemIrrlicht* vsys, bool& buttonPressed)
-		: pressed(buttonPressed) {
-		// store pointer application
-		vis = vsys;
-
-		// ..add a GUI button to control pause/play
-		pauseButton = vis->GetGUIEnvironment()->addButton(rect<s32>(510, 20, 650, 35));
-		buttonText = vis->GetGUIEnvironment()->addStaticText(L"Paused", rect<s32>(560, 20, 600, 35), false);
-	}
-
-	bool OnEvent(const SEvent& event) {
-		// check if user clicked button
-		if (event.EventType == EET_GUI_EVENT) {
-			switch (event.GUIEvent.EventType) {
-			case EGET_BUTTON_CLICKED:
-				pressed = !pressed;
-				if (pressed) {
-					buttonText->setText(L"Playing");
-				}
-				else {
-					buttonText->setText(L"Paused");
-				}
-				return pressed;
-				break;
-			default:
-				break;
-			}
-		}
-		return false;
-	}
-
-private:
-	ChVisualSystemIrrlicht* vis;
-	IGUIButton* pauseButton;
-	IGUIStaticText* buttonText;
-
-	bool& pressed;
-};
-
+// usage: ./<demos>.exe [DATADIR] [--nogui]
+//
+// If no argument is given user can set HYDROCHRONO_DATA_DIR 
+// environment variable to give the data_directory.
+// 
 int main(int argc, char* argv[]) {
-	//auto start = std::chrono::high_resolution_clock::now();
-	GetLog() << "Chrono version: " << CHRONO_VERSION << "\n\n";
 
+	GetLog() << "Chrono version: " << CHRONO_VERSION << "\n\n";
 
 	if (hydroc::setInitialEnvironment(argc, argv) != 0) {
 		return 1;
 	}
 
+	// Check if --nogui option is set as 2nd argument
+	bool visualizationOn = true;
+	if(argc > 2 &&  std::string("--nogui").compare(argv[2]) == 0)  {
+		visualizationOn = false;
+	}
+
+	// Get model file names
 	std::filesystem::path DATADIR(hydroc::getDataDir());
 
 	auto body1_meshfame = (DATADIR / "oswec" / "geometry" / "flap.obj")
@@ -87,6 +46,7 @@ int main(int argc, char* argv[]) {
 
 	// system/solver settings
 	ChSystemNSC system;
+
 	system.Set_G_acc(ChVector<>(0.0, 0.0, -9.81));
 	double timestep = 0.03;
 	//system.SetTimestepperType(ChTimestepper::Type::HHT);
@@ -96,8 +56,11 @@ int main(int argc, char* argv[]) {
 	ChRealtimeStepTimer realtime_timer;
 	double simulationDuration = 400.0;
 
+	// Create user interface
+	std::shared_ptr<hydroc::gui::UI> pui = hydroc::gui::CreateUI(visualizationOn);
+	hydroc::gui::UI& ui = *pui.get();
+
 	// some io/viz options
-	bool visualizationOn = true;
 	bool profilingOn = false;
 	bool saveDataOn = true;
 	std::vector<double> time_vector;
@@ -113,15 +76,10 @@ int main(int argc, char* argv[]) {
 		false                                                                                     // collisions
 		);
 
-	// set up body from a mesh
-	std::cout << "Attempting to open mesh file: " << body2_meshfame << std::endl;
-	std::shared_ptr<ChBody> base_body = chrono_types::make_shared<ChBodyEasyMesh>(                   //
-		body2_meshfame,
-		1000,                                                                                     // density
-		false,                                                                                    // do not evaluate mass automatically
-		true,                                                                                     // create visualization asset
-		false                                                                                     // collisions
-		);
+	// Create a visualization material
+	auto red = chrono_types::make_shared<ChVisualMaterial>();
+	red->SetDiffuseColor(ChColor(0.3f, 0.1f, 0.1f));
+	flap_body->GetVisualShape(0)->SetMaterial(0, red);
 
 	// define the float's initial conditions
 	system.Add(flap_body);
@@ -134,6 +92,22 @@ int main(int argc, char* argv[]) {
 	flap_body->SetMass(127000.0);
 	flap_body->SetInertiaXX(ChVector<>(1.85e6, 1.85e6, 1.85e6));
 	// notes: mass and inertia added to added mass and system mass correctly.
+
+
+	// set up body from a mesh
+	std::cout << "Attempting to open mesh file: " << body2_meshfame << std::endl;
+	std::shared_ptr<ChBody> base_body = chrono_types::make_shared<ChBodyEasyMesh>(                   //
+		body2_meshfame,
+		1000,                                                                                     // density
+		false,                                                                                    // do not evaluate mass automatically
+		true,                                                                                     // create visualization asset
+		false                                                                                     // collisions
+		);
+
+	// Create a visualization material
+	auto blue = chrono_types::make_shared<ChVisualMaterial>();
+	blue->SetDiffuseColor(ChColor(0.3f, 0.1f, 0.6f));
+	base_body->GetVisualShape(0)->SetMaterial(0, blue);
 
 	// define the plate's initial conditions
 	system.Add(base_body);
@@ -164,59 +138,22 @@ int main(int argc, char* argv[]) {
 	// for profiling
 	auto start = std::chrono::high_resolution_clock::now();
 
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-	if (visualizationOn) {
-		// create the irrlicht application for visualizing
-		auto irrlichtVis = chrono_types::make_shared<ChVisualSystemIrrlicht>();
-		irrlichtVis->AttachSystem(&system);
-		irrlichtVis->SetWindowSize(1280, 720);
-		irrlichtVis->SetWindowTitle("OSWEC - Decay Test");
-		irrlichtVis->SetCameraVertical(CameraVerticalDir::Z);
-		irrlichtVis->Initialize();
-		irrlichtVis->AddLogo();
-		irrlichtVis->AddSkyBox();
-		irrlichtVis->AddCamera(ChVector<>(0, -50, -10), ChVector<>(0, 0, -10)); // camera position and where it points
-		irrlichtVis->AddTypicalLights();
+	// main simulation loop
+	ui.Init(&system, "OSWEC - Decay Test");
+	ui.SetCamera(0, -50, -10, 0, 0, -10);
 
-		// add play/pause button
-		bool buttonPressed = false;
-		MyActionReceiver receiver(irrlichtVis.get(), buttonPressed);
-		irrlichtVis->AddUserEventReceiver(&receiver);
+	while (system.GetChTime() <= simulationDuration) {
 
-		// main simulation loop
-		while (irrlichtVis->Run() && system.GetChTime() <= simulationDuration) {
-			irrlichtVis->BeginScene();
-			irrlichtVis->Render();
-			irrlicht::tools::drawAllCOGs(irrlichtVis.get(), 10.0);
-			irrlichtVis->EndScene();
-			if (buttonPressed) {
-				// step the simulation forwards
-				system.DoStepDynamics(timestep);
-				// append data to std vector
-				time_vector.push_back(system.GetChTime());
-				flap_rot.push_back(flap_body->GetRot().Q_to_Euler123().y());
-				// force playback to be real-time
-				realtime_timer.Spin(timestep);
-				//ChSparseMatrix M;
-				//system.GetMassMatrix(&M);
-				//std::cout << M << std::endl;
-			}
-		}
-	}
-	else {
-#endif // #ifdef HYDROCHRONO_HAVE_IRRLICHT
-		int frame = 0;
-		while (system.GetChTime() <= simulationDuration) {
-			// append data to std vector
+		if(ui.IsRunning(timestep) == false) break;
+		
+		if (ui.simulationStarted) {
+
+			// append data to output vector
 			time_vector.push_back(system.GetChTime());
-			flap_rot.push_back(flap_body->GetRot().Q_to_Euler123().y());
-			// step the simulation forwards
-			system.DoStepDynamics(timestep);
-			frame++;
+			flap_rot.push_back(flap_body->GetRot().Q_to_Euler123().y());		
 		}
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
 	}
-#endif
+
 
 	// for profiling
 	auto end = std::chrono::high_resolution_clock::now();

--- a/demos/rm3/rm3_decay.cpp
+++ b/demos/rm3/rm3_decay.cpp
@@ -1,20 +1,6 @@
 #include <hydroc/hydro_forces.h>
-
 #include <hydroc/helper.h>
-
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-	#include "chrono_irrlicht/ChVisualSystemIrrlicht.h"
-	#include "chrono_irrlicht/ChIrrMeshTools.h"
-	// Use the main namespaces of Irrlicht
-	using namespace irr;
-	using namespace irr::core;
-	using namespace irr::scene;
-	using namespace irr::video;
-	using namespace irr::io;
-	using namespace irr::gui;
-	using namespace chrono::irrlicht;
-#endif
-
+#include <hydroc/gui/guihelper.h>
 
 #include <chrono/core/ChRealtimeStep.h>
 
@@ -27,50 +13,12 @@ using namespace chrono;
 using namespace chrono::geometry;
 
 
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-class MyActionReceiver : public IEventReceiver {
-public:
-	MyActionReceiver(ChVisualSystemIrrlicht* vsys, bool& buttonPressed)
-		: pressed(buttonPressed) {
-		// store pointer application
-		vis = vsys;
 
-		// ..add a GUI button to control pause/play
-		pauseButton = vis->GetGUIEnvironment()->addButton(rect<s32>(510, 20, 650, 35));
-		buttonText = vis->GetGUIEnvironment()->addStaticText(L"Paused", rect<s32>(560, 20, 600, 35), false);
-	}
-
-	bool OnEvent(const SEvent& event) {
-		// check if user clicked button
-		if (event.EventType == EET_GUI_EVENT) {
-			switch (event.GUIEvent.EventType) {
-			case EGET_BUTTON_CLICKED:
-				pressed = !pressed;
-				if (pressed) {
-					buttonText->setText(L"Playing");
-				}
-				else {
-					buttonText->setText(L"Paused");
-				}
-				return pressed;
-				break;
-			default:
-				break;
-			}
-		}
-		return false;
-	}
-
-private:
-	ChVisualSystemIrrlicht* vis;
-	IGUIButton* pauseButton;
-	IGUIStaticText* buttonText;
-
-	bool& pressed;
-};
-#endif
-
-
+// usage: ./<demos>.exe [DATADIR] [--nogui]
+//
+// If no argument is given user can set HYDROCHRONO_DATA_DIR 
+// environment variable to give the data_directory.
+// 
 int main(int argc, char* argv[]) {
 
 	GetLog() << "Chrono version: " << CHRONO_VERSION << "\n\n";
@@ -79,6 +27,13 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+	// Check if --nogui option is set as 2nd argument
+	bool visualizationOn = true;
+	if(argc > 2 &&  std::string("--nogui").compare(argv[2]) == 0)  {
+		visualizationOn = false;
+	}
+
+	// Get model file names
     std::filesystem::path DATADIR(hydroc::getDataDir());
 
 	auto body1_meshfame = (DATADIR / "rm3" / "geometry" /"float_cog.obj")
@@ -93,9 +48,10 @@ int main(int argc, char* argv[]) {
 
 	// system/solver settings
 	ChSystemNSC system;
+
 	system.Set_G_acc(ChVector<>(0.0, 0.0, -9.81));
+
 	double timestep = 0.01;
-	//system.SetSolverType(ChSolver::Type::GMRES);
 	system.SetTimestepperType(ChTimestepper::Type::HHT);
 	system.SetSolverType(ChSolver::Type::GMRES);
 	system.SetSolverMaxIterations(300);  // the higher, the easier to keep the constraints satisfied.
@@ -103,8 +59,12 @@ int main(int argc, char* argv[]) {
 	ChRealtimeStepTimer realtime_timer;
 	double simulationDuration = 300.0;
 
+	// Create user interface
+	std::shared_ptr<hydroc::gui::UI> pui = hydroc::gui::CreateUI(visualizationOn);
+
+	hydroc::gui::UI& ui = *pui.get();
+
 	// some io/viz options
-	bool visualizationOn = true;
 	bool profilingOn = false;
 	bool saveDataOn = true;
 	std::vector<double> time_vector;
@@ -122,6 +82,20 @@ int main(int argc, char* argv[]) {
 		false                                                                                     // collisions
 		);
 
+	// define the float's initial conditions
+	system.Add(float_body1);
+	float_body1->SetNameString("body1"); 
+	float_body1->SetPos(ChVector<>(0, 0, (-0.72+0.1)));
+	float_body1->SetMass(725834);
+	float_body1->SetInertiaXX(ChVector<>(20907301.0, 21306090.66, 37085481.11));
+	//float_body1->SetCollide(false);
+
+	// Create a visualization material
+	auto red = chrono_types::make_shared<ChVisualMaterial>();
+	red->SetDiffuseColor(ChColor(0.3f, 0.1f, 0.1f));
+	float_body1->GetVisualShape(0)->SetMaterial(0, red);
+
+	// Plate
 	std::cout << "Attempting to open mesh file: " << body2_meshfame << std::endl;
 	std::shared_ptr<ChBody> plate_body2 = chrono_types::make_shared<ChBodyEasyMesh>(                   //
 		body2_meshfame, 
@@ -131,13 +105,10 @@ int main(int argc, char* argv[]) {
 		false                                                                                     // collisions
 		);
 
-	// define the float's initial conditions
-	system.Add(float_body1);
-	float_body1->SetNameString("body1"); 
-	float_body1->SetPos(ChVector<>(0, 0, (-0.72+0.1)));
-	float_body1->SetMass(725834);
-	float_body1->SetInertiaXX(ChVector<>(20907301.0, 21306090.66, 37085481.11));
-	//float_body1->SetCollide(false);
+	// Create a visualization material
+	auto blue = chrono_types::make_shared<ChVisualMaterial>();
+	blue->SetDiffuseColor(ChColor(0.3f, 0.1f, 0.6f));
+	plate_body2->GetVisualShape(0)->SetMaterial(0, blue);
 
 	// define the plate's initial conditions
 	system.Add(plate_body2);
@@ -177,61 +148,24 @@ int main(int argc, char* argv[]) {
 	// for profiling
 	auto start = std::chrono::high_resolution_clock::now();
 
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-	if (visualizationOn) {
+	// main simulation loop
+	ui.Init(&system, "RM3 - Decay Test");
+	ui.SetCamera(0, -50, -10, 0, 0, -10);
 
-		// create the irrlicht application for visualizing
-		auto irrlichtVis = chrono_types::make_shared<ChVisualSystemIrrlicht>();
-		irrlichtVis->AttachSystem(&system);
-		irrlichtVis->SetWindowSize(1280, 720);
-		irrlichtVis->SetWindowTitle("RM3 - Decay Test");
-		irrlichtVis->SetCameraVertical(CameraVerticalDir::Z);
-		irrlichtVis->Initialize();
-		irrlichtVis->AddLogo();
-		irrlichtVis->AddSkyBox();
-		irrlichtVis->AddCamera(ChVector<>(0, -50, -10), ChVector<>(0, 0, -10)); // camera position and where it points
-		irrlichtVis->AddTypicalLights();
+	while (system.GetChTime() <= simulationDuration) {
 
-		// add play/pause button
-		bool buttonPressed = false;
-		MyActionReceiver receiver(irrlichtVis.get(), buttonPressed);
-		irrlichtVis->AddUserEventReceiver(&receiver);
+		if(ui.IsRunning(timestep) == false) break;
+		
+		if (ui.simulationStarted) {
 
-		// main simulation loop
-		while (irrlichtVis->Run() && system.GetChTime() <= simulationDuration) {
-			irrlichtVis->BeginScene();
-			irrlichtVis->Render();
-			irrlichtVis->EndScene();
-			if (buttonPressed) {
-				//system.GetMassMatrix(&M);
-				//std::cout << M << std::endl;
-				// step the simulation forwards
-				system.DoStepDynamics(timestep);
-				// append data to std vector
-				time_vector.push_back(system.GetChTime());
-				float_heave_position.push_back(float_body1->GetPos().z());
-				plate_heave_position.push_back(plate_body2->GetPos().z());
-				// force playback to be real-time
-				realtime_timer.Spin(timestep);
-			}
-		}
-	}
-	else {
-#endif // #ifdef HYDROCHRONO_HAVE_IRRLICHT
-		int frame = 0;
-		while (system.GetChTime() <= simulationDuration) {
-			// append data to std vector
+			// append data to output vector
 			time_vector.push_back(system.GetChTime());
 			float_heave_position.push_back(float_body1->GetPos().z());
 			plate_heave_position.push_back(plate_body2->GetPos().z());
-			// step the simulation forwards
-			system.DoStepDynamics(timestep);
 
-			frame++;
 		}
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
 	}
-#endif
+
 
 	// for profiling
 	auto end = std::chrono::high_resolution_clock::now();

--- a/demos/rm3/rm3_reg_waves.cpp
+++ b/demos/rm3/rm3_reg_waves.cpp
@@ -1,20 +1,6 @@
 #include <hydroc/hydro_forces.h>
-
 #include <hydroc/helper.h>
-
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-	#include "chrono_irrlicht/ChVisualSystemIrrlicht.h"
-	#include "chrono_irrlicht/ChIrrMeshTools.h"
-	// Use the main namespaces of Irrlicht
-	using namespace irr;
-	using namespace irr::core;
-	using namespace irr::scene;
-	using namespace irr::video;
-	using namespace irr::io;
-	using namespace irr::gui;
-	using namespace chrono::irrlicht;
-#endif
-
+#include <hydroc/gui/guihelper.h>
 
 #include <chrono/core/ChRealtimeStep.h>
 
@@ -26,61 +12,26 @@
 using namespace chrono;
 using namespace chrono::geometry;
 
-
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-// Define a class to manage user inputs via the GUI (i.e. play/pause button)
-class MyActionReceiver : public IEventReceiver {
-	public:
-		MyActionReceiver(ChVisualSystemIrrlicht* vsys, bool& buttonPressed)
-			: pressed(buttonPressed) {
-			// store pointer application
-			vis = vsys;
-
-			// ..add a GUI button to control pause/play
-			pauseButton = vis->GetGUIEnvironment()->addButton(rect<s32>(510, 20, 650, 35));
-			buttonText = vis->GetGUIEnvironment()->addStaticText(L"Paused", rect<s32>(560, 20, 600, 35), false);
-		}
-
-		bool OnEvent(const SEvent& event) {
-			// check if user clicked button
-			if (event.EventType == EET_GUI_EVENT) {
-				switch (event.GUIEvent.EventType) {
-				case EGET_BUTTON_CLICKED:
-					pressed = !pressed;
-					if (pressed) {
-						buttonText->setText(L"Playing");
-					}
-					else {
-						buttonText->setText(L"Paused");
-					}
-					return pressed;
-					break;
-				default:
-					break;
-				}
-			}
-			return false;
-		}
-
-	private:
-		ChVisualSystemIrrlicht* vis;
-		IGUIButton* pauseButton;
-		IGUIStaticText* buttonText;
-
-		bool& pressed;
-};
-#endif
-
-
+// usage: ./<demos>.exe [DATADIR] [--nogui]
+//
+// If no argument is given user can set HYDROCHRONO_DATA_DIR 
+// environment variable to give the data_directory.
+// 
 int main(int argc, char* argv[]) {
-	//auto start = std::chrono::high_resolution_clock::now();
-	GetLog() << "Chrono version: " << CHRONO_VERSION << "\n\n";
 
+	GetLog() << "Chrono version: " << CHRONO_VERSION << "\n\n";
 
     if (hydroc::setInitialEnvironment(argc, argv) != 0) {
         return 1;
     }
 
+	// Check if --nogui option is set as 2nd argument
+	bool visualizationOn = true;
+	if(argc > 2 &&  std::string("--nogui").compare(argv[2]) == 0)  {
+		visualizationOn = false;
+	}
+
+	// Get model file names
     std::filesystem::path DATADIR(hydroc::getDataDir());
 
 	auto body1_meshfame = (DATADIR / "rm3" / "geometry" /"float_cog.obj")
@@ -96,6 +47,7 @@ int main(int argc, char* argv[]) {
 
 	// system/solver settings
 	ChSystemNSC system;
+
 	system.Set_G_acc(ChVector<>(0.0, 0.0, -9.81));
 	double timestep = 0.01;
 	system.SetTimestepperType(ChTimestepper::Type::HHT);
@@ -105,8 +57,12 @@ int main(int argc, char* argv[]) {
 	ChRealtimeStepTimer realtime_timer;
 	double simulationDuration = 40.0;
 
+	// Create user interface
+	std::shared_ptr<hydroc::gui::UI> pui = hydroc::gui::CreateUI(visualizationOn);
+
+	hydroc::gui::UI& ui = *pui.get();
+
 	// some io/viz options
-	bool visualizationOn = true;
 	bool profilingOn = true;
 	bool saveDataOn = true;
 	std::vector<double> time_vector;
@@ -124,6 +80,19 @@ int main(int argc, char* argv[]) {
 		false                                                                                     // collisions
 		);
 
+	// define the float's initial conditions
+	system.Add(float_body1);
+	float_body1->SetNameString("body1"); 
+	float_body1->SetPos(ChVector<>(0, 0, -0.72));
+	float_body1->SetMass(725834);
+	float_body1->SetInertiaXX(ChVector<>(20907301.0, 21306090.66, 37085481.11));
+	//float_body1->SetCollide(false);
+
+	// Create a visualization material
+	auto red = chrono_types::make_shared<ChVisualMaterial>();
+	red->SetDiffuseColor(ChColor(0.3f, 0.1f, 0.1f));
+	float_body1->GetVisualShape(0)->SetMaterial(0, red);
+
 	std::cout << "Attempting to open mesh file: " << body2_meshfame << std::endl;
 	std::shared_ptr<ChBody> plate_body2 = chrono_types::make_shared<ChBodyEasyMesh>(                   //
 		body2_meshfame, 
@@ -133,13 +102,10 @@ int main(int argc, char* argv[]) {
 		false                                                                                     // collisions
 		);
 
-	// define the float's initial conditions
-	system.Add(float_body1);
-	float_body1->SetNameString("body1"); 
-	float_body1->SetPos(ChVector<>(0, 0, -0.72));
-	float_body1->SetMass(725834);
-	float_body1->SetInertiaXX(ChVector<>(20907301.0, 21306090.66, 37085481.11));
-	//float_body1->SetCollide(false);
+	// Create a visualization material
+	auto blue = chrono_types::make_shared<ChVisualMaterial>();
+	blue->SetDiffuseColor(ChColor(0.3f, 0.1f, 0.6f));
+	plate_body2->GetVisualShape(0)->SetMaterial(0, blue);
 
 	// define the plate's initial conditions
 	system.Add(plate_body2);
@@ -175,61 +141,24 @@ int main(int argc, char* argv[]) {
 	// for profiling
 	auto start = std::chrono::high_resolution_clock::now();
 
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-	if (visualizationOn) {
-		// create the irrlicht application for visualizing
-		auto irrlichtVis = chrono_types::make_shared<ChVisualSystemIrrlicht>();
-		irrlichtVis->AttachSystem(&system);
-		irrlichtVis->SetWindowSize(1280, 720);
-		irrlichtVis->SetWindowTitle("RM3 - Regular Wave Test");
-		irrlichtVis->SetCameraVertical(CameraVerticalDir::Z);
-		irrlichtVis->Initialize();
-		irrlichtVis->AddLogo();
-		irrlichtVis->AddSkyBox();
-		irrlichtVis->AddCamera(ChVector<>(0, -50, -10), ChVector<>(0, 0, -10)); // camera position and where it points
-		irrlichtVis->AddTypicalLights();
+	// main simulation loop
+	ui.Init(&system, "RM3 - Regular Wave Test");
+	ui.SetCamera(0, -50, -10, 0, 0, -10);
 
-		// add play/pause button
-		bool buttonPressed = false;
-		MyActionReceiver receiver(irrlichtVis.get(), buttonPressed);
-		irrlichtVis->AddUserEventReceiver(&receiver);
+	while (system.GetChTime() <= simulationDuration) {
 
-		// main simulation loop
-		while (irrlichtVis->Run() && system.GetChTime() <= simulationDuration) {
-			irrlichtVis->BeginScene();
-			irrlichtVis->Render();
-			irrlichtVis->EndScene();
-			if (buttonPressed) {
-				// step the simulation forwards
-				system.DoStepDynamics(timestep);
-				// append data to std vector
-				time_vector.push_back(system.GetChTime());
-				float_heave_position.push_back(float_body1->GetPos().z());
-				float_drift_position.push_back(float_body1->GetPos().x());
-				plate_heave_position.push_back(plate_body2->GetPos().z());
-				// force playback to be real-time
-				realtime_timer.Spin(timestep);
-			}
-		}
-	}
-	else {
-#endif // #ifdef HYDROCHRONO_HAVE_IRRLICHT
-		int frame = 0;
-		while (system.GetChTime() <= simulationDuration) {
-			// append data to std vector
+		if(ui.IsRunning(timestep) == false) break;
+		
+		if (ui.simulationStarted) {
+
+			// append data to output vector
 			time_vector.push_back(system.GetChTime());
 			float_heave_position.push_back(float_body1->GetPos().z());
 			float_drift_position.push_back(float_body1->GetPos().x());
-			plate_heave_position.push_back(plate_body2->GetPos().z());
-
-			// step the simulation forwards
-			system.DoStepDynamics(timestep);
-
-			frame++;
+			plate_heave_position.push_back(plate_body2->GetPos().z());			
 		}
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
 	}
-#endif
+
 
 	// for profiling
 	auto end = std::chrono::high_resolution_clock::now();

--- a/demos/sphere/sphere_decay.cpp
+++ b/demos/sphere/sphere_decay.cpp
@@ -1,18 +1,8 @@
 #include <hydroc/hydro_forces.h>
 #include <hydroc/helper.h>
 
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-	#include "chrono_irrlicht/ChVisualSystemIrrlicht.h"
-	#include "chrono_irrlicht/ChIrrMeshTools.h"
-	// Use the main namespaces of Irrlicht
-	using namespace irr;
-	using namespace irr::core;
-	using namespace irr::scene;
-	using namespace irr::video;
-	using namespace irr::io;
-	using namespace irr::gui;
-	using namespace chrono::irrlicht;
-#endif
+#include <hydroc/gui/guihelper.h>
+
 
 #include "chrono/core/ChRealtimeStep.h"
 
@@ -26,49 +16,6 @@
 using namespace chrono;
 using namespace chrono::geometry;
 
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-// Define a class to manage user inputs via the GUI (i.e. play/pause button)
-class MyActionReceiver : public IEventReceiver {
-	public:
-		MyActionReceiver(ChVisualSystemIrrlicht* vsys, bool& buttonPressed)
-			: pressed(buttonPressed) {
-			// store pointer application
-			vis = vsys;
-
-			// ..add a GUI button to control pause/play
-			pauseButton = vis->GetGUIEnvironment()->addButton(rect<s32>(510, 20, 650, 35));
-			buttonText = vis->GetGUIEnvironment()->addStaticText(L"Paused", rect<s32>(560, 20, 600, 35), false);
-		}
-
-		bool OnEvent(const SEvent& event) {
-			// check if user clicked button
-			if (event.EventType == EET_GUI_EVENT) {
-				switch (event.GUIEvent.EventType) {
-				case EGET_BUTTON_CLICKED:
-					pressed = !pressed;
-					if (pressed) {
-						buttonText->setText(L"Playing");
-					}
-					else {
-						buttonText->setText(L"Paused");
-					}
-					return pressed;
-					break;
-				default:
-					break;
-				}
-			}
-			return false;
-		}
-
-	private:
-		ChVisualSystemIrrlicht* vis;
-		IGUIButton* pauseButton;
-		IGUIStaticText* buttonText;
-
-		bool& pressed;
-};
-#endif
 
 
 // the main program to be executed:
@@ -88,7 +35,9 @@ int main(int argc, char* argv[]) {
 
 	// system/solver settings
 	ChSystemNSC system;
+
 	system.Set_G_acc(ChVector<>(0.0, 0.0, -9.81));
+
 	double timestep = 0.015;
 	system.SetSolverType(ChSolver::Type::GMRES);
 	system.SetSolverMaxIterations(300);  // the higher, the easier to keep the constraints satisfied.
@@ -96,13 +45,17 @@ int main(int argc, char* argv[]) {
 	ChRealtimeStepTimer realtime_timer;
 	double simulationDuration = 40.0;
 
-	// some io/viz options
-	bool visualizationOn = false;
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-	visualizationOn = true;
-#endif
+	// Create user interface
+	bool visualizationOn = true;
+
+	std::shared_ptr<hydroc::gui::UI> pui = hydroc::gui::CreateUI(visualizationOn);
+
+	hydroc::gui::UI& ui = *pui.get();
+
 	bool profilingOn = true;
 	bool saveDataOn = true;
+
+	// Output timeseries
 	std::vector<double> time_vector;
 	std::vector<double> heave_position;
 
@@ -117,10 +70,17 @@ int main(int argc, char* argv[]) {
 		);
 
 	// define the body's initial conditions
-	system.Add(sphereBody);
 	sphereBody->SetNameString("body1"); // must set body name correctly! (must match .h5 file)
 	sphereBody->SetPos(ChVector<>(0, 0, -1));
 	sphereBody->SetMass(261.8e3);
+
+	// Create a visualization material
+	auto cadet_blue = chrono_types::make_shared<ChVisualMaterial>();
+	cadet_blue->SetDiffuseColor(ChColor(0.3f, 0.1f, 0.1f));
+	sphereBody->GetVisualShape(0)->SetMaterial(0, cadet_blue);
+
+	system.Add(sphereBody);
+
 
 	// define wave parameters (not used in this demo)
 	// Todo define a way to use TestHydro without hydro_inputs/waves
@@ -132,80 +92,29 @@ int main(int argc, char* argv[]) {
 	// attach hydrodynamic forces to body
 	std::vector<std::shared_ptr<ChBody>> bodies;
 	bodies.push_back(sphereBody);
+
+
 	TestHydro blah(bodies, h5fname, my_hydro_inputs);
 
 	// for profilingvisualizationOn = false;
 	auto start = std::chrono::high_resolution_clock::now(); 
 
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-	if (visualizationOn){
+	// main simulation loop
+	ui.Init(&system, "Sphere - Decay Test"); 
 
-		// Create a visualization material
-		auto cadet_blue = chrono_types::make_shared<ChVisualMaterial>();
-		cadet_blue->SetDiffuseColor(ChColor(0.3f, 0.1f, 0.1f));
-		sphereBody->GetVisualShape(0)->SetMaterial(0, cadet_blue);
+	while (system.GetChTime() <= simulationDuration) {
 
-		// create the irrlicht application for visualizing
-		auto irrlichtVis = chrono_types::make_shared<ChVisualSystemIrrlicht>();
-
-
-
-		irrlichtVis->AttachSystem(&system);
-		irrlichtVis->SetWindowSize(1280, 720);
-		irrlichtVis->SetWindowTitle("Sphere - Decay Test");
-		irrlichtVis->SetCameraVertical(CameraVerticalDir::Z);
-		irrlichtVis->Initialize();
-
-		irrlichtVis->AddLogo();
-		irrlichtVis->AddSkyBox();
-		irrlichtVis->AddCamera(ChVector<>(8, -25, 15), ChVector<>(0, 0, 0));
-		irrlichtVis->AddTypicalLights();
+		if(ui.IsRunning(timestep) == false) break;
 		
+		if (ui.simulationStarted) {
 
-		// add play/pause button
-		bool buttonPressed = false;
-		MyActionReceiver receiver(irrlichtVis.get(), buttonPressed);
-		irrlichtVis->AddUserEventReceiver(&receiver);
-
-		// main simulation loop
-		while (irrlichtVis->Run() && system.GetChTime() <= simulationDuration) {
-
-
-			irrlichtVis->BeginScene();
-			irrlichtVis->Render();
-
-			// Add grid to materialize horizontal plane 
-			tools::drawGrid(irrlichtVis.get(), 1, 1, 30, 30,
-				ChCoordsys<>(ChVector<>(0, 0.0, 0), Q_from_AngZ(CH_C_PI_2)),
-				chrono::ChColor(.1f, .1f, .1f), true);
-
-
-			irrlichtVis->EndScene();
-			if (buttonPressed) {
-				// step the simulation forwards
-				system.DoStepDynamics(timestep);
-				// append data to std vector
-				time_vector.push_back(system.GetChTime());
-				heave_position.push_back(sphereBody->GetPos().z());
-				// force playback to be real-time
-				// realtime_timer.Spin(timestep);
-			}
-		}
-	}
-	else{
-#endif // #ifdef HYDROCHRONO_HAVE_IRRLICHT
-		int frame = 0;
-		while (system.GetChTime() <= simulationDuration) {
-			// step the simulation forwards
-			system.DoStepDynamics(timestep);
-			// append data to std vector
+			// append data to output vector
 			time_vector.push_back(system.GetChTime());
 			heave_position.push_back(sphereBody->GetPos().z());
-			frame++;
+
 		}
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
 	}
-#endif
+
 
 	// for profiling
 	auto end = std::chrono::high_resolution_clock::now();
@@ -257,5 +166,6 @@ int main(int argc, char* argv[]) {
 		outputFile.close();
 	}
 
+	std::cout << "Simulation finished." << std::endl;
 	return 0;
 }

--- a/demos/sphere/sphere_decay.cpp
+++ b/demos/sphere/sphere_decay.cpp
@@ -1,11 +1,8 @@
 #include <hydroc/hydro_forces.h>
 #include <hydroc/helper.h>
-
 #include <hydroc/gui/guihelper.h>
 
-
-#include "chrono/core/ChRealtimeStep.h"
-
+#include <chrono/core/ChRealtimeStep.h>
 
 #include <iomanip> // std::setprecision
 #include <chrono> // std::chrono::high_resolution_clock::now

--- a/demos/sphere/sphere_decay.cpp
+++ b/demos/sphere/sphere_decay.cpp
@@ -17,8 +17,11 @@ using namespace chrono;
 using namespace chrono::geometry;
 
 
-
-// the main program to be executed:
+// usage: ./sphere_deca.exe [DATADIR] [--nogui]
+//
+// If no argument is given user can set HYDROCHRONO_DATA_DIR 
+// environment variable to give the data_directory.
+// 
 int main(int argc, char* argv[]) {
 	GetLog() << "Chrono version: " << CHRONO_VERSION << "\n\n";
 
@@ -26,12 +29,17 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+	// Check if --nogui option is set as 2nd argument
+	bool visualizationOn = true;
+	if(argc > 2 &&  std::string("--nogui").compare(argv[2]) == 0)  {
+		visualizationOn = false;
+	}
+
+	// Get model file names
     std::filesystem::path DATADIR(hydroc::getDataDir());
 
 	auto body1_meshfame = (DATADIR / "sphere" / "geometry" /"oes_task10_sphere.obj").lexically_normal().generic_string();
 	auto h5fname = (DATADIR / "sphere" / "hydroData" /"sphere.h5").lexically_normal().generic_string();
-
-
 
 	// system/solver settings
 	ChSystemNSC system;
@@ -46,8 +54,6 @@ int main(int argc, char* argv[]) {
 	double simulationDuration = 40.0;
 
 	// Create user interface
-	bool visualizationOn = true;
-
 	std::shared_ptr<hydroc::gui::UI> pui = hydroc::gui::CreateUI(visualizationOn);
 
 	hydroc::gui::UI& ui = *pui.get();

--- a/demos/sphere/sphere_reg_waves.cpp
+++ b/demos/sphere/sphere_reg_waves.cpp
@@ -1,19 +1,6 @@
 #include <hydroc/hydro_forces.h>
 #include <hydroc/helper.h>
-
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-	#include "chrono_irrlicht/ChVisualSystemIrrlicht.h"
-	#include "chrono_irrlicht/ChIrrMeshTools.h"
-	// Use the main namespaces of Irrlicht
-	using namespace irr;
-	using namespace irr::core;
-	using namespace irr::scene;
-	using namespace irr::video;
-	using namespace irr::io;
-	using namespace irr::gui;
-	using namespace chrono::irrlicht;
-#endif
-
+#include <hydroc/gui/guihelper.h>
 
 #include <chrono/core/ChRealtimeStep.h>
 
@@ -26,58 +13,25 @@
 using namespace chrono;
 using namespace chrono::geometry;
 
-
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-class MyActionReceiver : public IEventReceiver {
-public:
-	MyActionReceiver(ChVisualSystemIrrlicht* vsys, bool& buttonPressed)
-		: pressed(buttonPressed) {
-		// store pointer application
-		vis = vsys;
-
-		// ..add a GUI button to control pause/play
-		pauseButton = vis->GetGUIEnvironment()->addButton(rect<s32>(510, 20, 650, 35));
-		buttonText = vis->GetGUIEnvironment()->addStaticText(L"Paused", rect<s32>(560, 20, 600, 35), false);
-	}
-
-	bool OnEvent(const SEvent& event) {
-		// check if user clicked button
-		if (event.EventType == EET_GUI_EVENT) {
-			switch (event.GUIEvent.EventType) {
-			case EGET_BUTTON_CLICKED:
-				pressed = !pressed;
-				if (pressed) {
-					buttonText->setText(L"Playing");
-				}
-				else {
-					buttonText->setText(L"Paused");
-				}
-				return pressed;
-				break;
-			default:
-				break;
-			}
-		}
-		return false;
-	}
-
-private:
-	ChVisualSystemIrrlicht* vis;
-	IGUIButton* pauseButton;
-	IGUIStaticText* buttonText;
-
-	bool& pressed;
-};
-#endif
-
+// usage: ./<demos>.exe [DATADIR] [--nogui]
+//
+// If no argument is given user can set HYDROCHRONO_DATA_DIR 
+// environment variable to give the data_directory.
+// 
 int main(int argc, char* argv[]) {
 	GetLog() << "Chrono version: " << CHRONO_VERSION << "\n\n";
-
 
     if (hydroc::setInitialEnvironment(argc, argv) != 0) {
         return 1;
     }
 
+	// Check if --nogui option is set as 2nd argument
+	bool visualizationOn = true;
+	if(argc > 2 &&  std::string("--nogui").compare(argv[2]) == 0)  {
+		visualizationOn = false;
+	}
+
+	// Get model file names
     std::filesystem::path DATADIR(hydroc::getDataDir());
 
 	auto body1_meshfame = (DATADIR / "sphere" / "geometry" /"oes_task10_sphere.obj")
@@ -97,6 +51,11 @@ int main(int argc, char* argv[]) {
 	ChRealtimeStepTimer realtime_timer;
 	double simulationDuration = 40.0;
 
+	// Create user interface
+	std::shared_ptr<hydroc::gui::UI> pui = hydroc::gui::CreateUI(visualizationOn);
+
+	hydroc::gui::UI& ui = *pui.get();
+
 	// Setup Ground
 	auto ground = chrono_types::make_shared<ChBody>();
 	system.AddBody(ground);
@@ -106,9 +65,10 @@ int main(int argc, char* argv[]) {
 	ground->SetCollide(false);
 
 	// some io/viz options
-	bool visualizationOn = true;
 	bool profilingOn = true;
 	bool saveDataOn = true;
+
+	// Output timeseries	
 	std::vector<double> time_vector;
 	std::vector<double> heave_position;
 
@@ -127,6 +87,12 @@ int main(int argc, char* argv[]) {
 	sphereBody->SetNameString("body1"); // must set body name correctly! (must match .h5 file)
 	sphereBody->SetPos(ChVector<>(0, 0, -2));
 	sphereBody->SetMass(261.8e3);
+
+	// Create a visualization material
+	auto red = chrono_types::make_shared<ChVisualMaterial>();
+	red->SetDiffuseColor(ChColor(0.3f, 0.1f, 0.1f));
+	sphereBody->GetVisualShape(0)->SetMaterial(0, red);
+
 
 	int reg_wave_num = 10;
 	double task10_wave_amps[] = { 0.044, 0.078, 0.095, 0.123, 0.177, 0.24, 0.314, 0.397, 0.491, 0.594 };
@@ -165,69 +131,21 @@ int main(int argc, char* argv[]) {
 	// for profiling
 	auto start = std::chrono::high_resolution_clock::now();
 	
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
-	if (visualizationOn) {
+	// main simulation loop
+	ui.Init(&system, "Sphere Reg Waves - Decay Test"); 
+	ui.SetCamera(8, -25, 15, 0, 0, 0);
 
-		// Create a visualization material
-		auto cadet_blue = chrono_types::make_shared<ChVisualMaterial>();
-		cadet_blue->SetDiffuseColor(ChColor(0.3f, 0.1f, 0.1f));
-		sphereBody->GetVisualShape(0)->SetMaterial(0, cadet_blue);
+	while (system.GetChTime() <= simulationDuration) {
 
-		// create the irrlicht application for visualizing
-		auto irrlichtVis = chrono_types::make_shared<ChVisualSystemIrrlicht>();
+		if(ui.IsRunning(timestep) == false) break;
 		
-		irrlichtVis->AttachSystem(&system);
-		irrlichtVis->SetWindowSize(1280, 720);
-		irrlichtVis->SetWindowTitle("Sphere - Regular Waves Test");
-		irrlichtVis->SetCameraVertical(CameraVerticalDir::Z);
-		irrlichtVis->Initialize();
-		
-		irrlichtVis->AddLogo();
-		irrlichtVis->AddSkyBox();
-		irrlichtVis->AddCamera(ChVector<>(8, -25, 15), ChVector<>(0, 0, 0));
-		irrlichtVis->AddTypicalLights();
+		if (ui.simulationStarted) {
 
-		// add play/pause button
-		bool buttonPressed = false;
-		MyActionReceiver receiver(irrlichtVis.get(), buttonPressed);
-		irrlichtVis->AddUserEventReceiver(&receiver);
-
-		// Main simulation loop
-		int frame = 0;
-		while (irrlichtVis->Run() && system.GetChTime() <= simulationDuration) {
-			irrlichtVis->BeginScene();
-			irrlichtVis->Render();
-
-			// Add grid to materialize horizontal plane 
-			tools::drawGrid(irrlichtVis.get(), 1, 1, 30, 30,
-				ChCoordsys<>(ChVector<>(0, 0.0, 0), Q_from_AngZ(CH_C_PI_2)),
-				chrono::ChColor(.1f, .1f, .1f), true);
-
-			irrlichtVis->EndScene();
-			if (buttonPressed) {
-				// step simulation forward
-				system.DoStepDynamics(timestep);
-				// append data to std vector
-				time_vector.push_back(system.GetChTime());
-				heave_position.push_back(sphereBody->GetPos().z());				
-				frame++;
-			}
-		}
-	}
-	else {
-#endif // #ifdef HYDROCHRONO_HAVE_IRRLICHT
-		int frame = 0;
-		while (system.GetChTime() <= simulationDuration) {
-			// step the simulation forwards
-			system.DoStepDynamics(timestep);
-			// append data to std vector
+			// append data to output vector
 			time_vector.push_back(system.GetChTime());
 			heave_position.push_back(sphereBody->GetPos().z());
-			frame++;
 		}
-#ifdef HYDROCHRONO_HAVE_IRRLICHT
 	}
-#endif
 
 	// for profiling
 	auto end = std::chrono::high_resolution_clock::now();

--- a/include/hydroc/gui/guihelper.h
+++ b/include/hydroc/gui/guihelper.h
@@ -32,6 +32,11 @@ struct UI {
 	*/
 	virtual void Init(chrono::ChSystem*, const char* title);
 
+	/**@brief Set Camera position and direction
+	 * 
+	*/
+	virtual void SetCamera(double x, double y, double z, double dirx, double diry, double dirz);
+
 	/**@brief To call during simulation loop  
 	 * 
 	*/
@@ -59,6 +64,7 @@ struct GUI: public UI {
 	GUI& operator = (const GUI&) = delete;
 
 	void Init(chrono::ChSystem*, const char* title) override;
+	void SetCamera(double x, double y, double z, double dirx, double diry, double dirz) override;
 	bool IsRunning(double timestep) override;
 
 private:

--- a/include/hydroc/gui/guihelper.h
+++ b/include/hydroc/gui/guihelper.h
@@ -1,0 +1,81 @@
+#pragma once
+
+
+#include <memory>
+
+namespace chrono {
+    class ChSystem;
+}
+
+
+
+namespace hydroc {
+    namespace gui {
+
+
+struct UI {
+
+	UI()
+	{
+	}
+	virtual ~UI() {}
+
+
+	UI(const UI&) = delete;
+	UI& operator = (const UI&) = delete;
+
+	/**@brief Initialize the system
+	 * 
+	 * Should be called after the given ChSystem is fully initialized
+	 * The best is to call it just before the simulation loop that call IsRunning
+	 * 
+	*/
+	virtual void Init(chrono::ChSystem*, const char* title);
+
+	/**@brief To call during simulation loop  
+	 * 
+	*/
+	virtual bool IsRunning(double timestep);
+
+
+	bool simulationStarted = true;
+
+protected:
+
+	int frame = 0;
+
+	chrono::ChSystem* pSystem = nullptr; // Do not manage the memory
+
+};
+
+
+class GUIImpl;
+
+
+struct GUI: public UI {
+
+	GUI();
+	GUI(const GUI&) = delete;
+	GUI& operator = (const GUI&) = delete;
+
+	void Init(chrono::ChSystem*, const char* title) override;
+	bool IsRunning(double timestep) override;
+
+private:
+	std::shared_ptr<hydroc::gui::GUIImpl> pImpl;
+};
+
+
+/**@brief Factory to create UI or GUI
+ * 
+*/
+std::shared_ptr<hydroc::gui::UI> CreateUI(bool visualizationOn = true);
+
+
+	} // end namespace gui
+	} // end namespace hydroc
+
+
+
+
+

--- a/src/gui/guihelper.cpp
+++ b/src/gui/guihelper.cpp
@@ -1,0 +1,239 @@
+#include <hydroc/gui/guihelper.h>
+using namespace hydroc::gui;
+
+#include <chrono/physics/ChSystem.h>
+
+
+#ifdef HYDROCHRONO_HAVE_IRRLICHT	
+	#include <IEventReceiver.h> // irrlicht
+
+	#include <chrono_irrlicht/ChVisualSystemIrrlicht.h>
+	#include <chrono_irrlicht/ChIrrMeshTools.h>
+
+	#include <chrono/core/ChVector.h>
+	#include <chrono/core/ChCoordsys.h>
+	#include <chrono/core/ChQuaternion.h>
+	#include <chrono/core/ChMathematics.h>
+
+	#include <chrono/assets/ChVisualSystem.h>
+	#include <chrono_irrlicht/ChVisualSystemIrrlicht.h>
+	#include <chrono_irrlicht/ChIrrMeshTools.h>
+#endif
+
+void UI::Init(chrono::ChSystem* system, const char* title) 
+{	
+	pSystem = system;
+
+}
+
+bool UI::IsRunning(double timestep) {
+
+
+	if (simulationStarted) {
+		// step the simulation forwards
+		pSystem->DoStepDynamics(timestep);
+
+		frame++;
+	}
+
+	return true;
+}
+
+
+
+std::shared_ptr<hydroc::gui::UI> hydroc::gui::CreateUI(bool visualizationOn) {
+
+	if (visualizationOn) {
+		return std::make_shared<hydroc::gui::GUI>();
+	} else {
+		return std::make_shared<hydroc::gui::UI>();
+	}
+
+}
+
+// Private implementation
+class hydroc::gui::GUIImpl {
+public:
+	GUIImpl();
+	GUIImpl(const GUIImpl&) = delete;
+	GUIImpl& operator = (const GUIImpl&) = delete;
+
+	void Init(UI& ui, chrono::ChSystem*, const char* title);
+	bool IsRunning(double timestep);
+private:
+#ifdef HYDROCHRONO_HAVE_IRRLICHT	
+	class MyActionReceiver;
+	void InitReceiver(bool& simulationStarted);
+	std::shared_ptr<chrono::irrlicht::ChVisualSystemIrrlicht> pVis;
+	std::shared_ptr<MyActionReceiver> receiver;
+#endif
+};
+
+
+
+
+#ifdef HYDROCHRONO_HAVE_IRRLICHT	
+
+
+using namespace chrono::irrlicht;
+
+using irr::core::rect;
+using irr::s32;
+using irr::EEVENT_TYPE;
+using irr::gui::EGUI_EVENT_TYPE;
+
+
+
+///@brief Define a class to manage user inputs via the GUI (i.e. play/pause button)
+class hydroc::gui::GUIImpl::MyActionReceiver : public irr::IEventReceiver {
+	public:
+		MyActionReceiver(bool& buttonPressed);
+		bool OnEvent(const irr::SEvent& event);
+        void Init(chrono::irrlicht::ChVisualSystemIrrlicht* vsys);
+	private:
+		chrono::irrlicht::ChVisualSystemIrrlicht* vis;
+		irr::gui::IGUIButton* pauseButton;
+		irr::gui::IGUIStaticText* buttonText;
+
+		bool& pressed;
+};
+
+
+
+
+GUIImpl::GUIImpl():
+		pVis(chrono_types::make_shared<chrono::irrlicht::ChVisualSystemIrrlicht>())
+{
+
+}
+
+void GUIImpl::InitReceiver(bool& theSimulationStarted) {
+
+	receiver = std::make_shared<MyActionReceiver>(theSimulationStarted);
+}
+
+void GUIImpl::Init(UI& ui, chrono::ChSystem* system, const char* title)
+{
+	pVis->AttachSystem(system);
+
+	pVis->SetWindowSize(1280, 720);
+	pVis->SetWindowTitle(title);
+	pVis->SetCameraVertical(chrono::CameraVerticalDir::Z);
+	pVis->Initialize();
+
+	InitReceiver(ui.simulationStarted);
+	receiver->Init(pVis.get());
+	pVis->AddUserEventReceiver(receiver.get());
+
+	pVis->AddLogo();
+	pVis->AddSkyBox();
+	pVis->AddCamera(chrono::ChVector<>(8, -25, 15), chrono::ChVector<>(0, 0, 0));
+	pVis->AddTypicalLights();
+}
+
+bool GUIImpl::IsRunning(double timestep) {
+	if(pVis->Run() == false) return false;
+
+	pVis->BeginScene();
+	pVis->Render();
+
+	// Add grid to materialize horizontal plane 
+	tools::drawGrid(pVis.get(), 1, 1, 30, 30,
+		chrono::ChCoordsys<>(chrono::ChVector<>(0, 0.0, 0), chrono::Q_from_AngZ(chrono::CH_C_PI_2)),
+		chrono::ChColor(.1f, .1f, .1f), true);
+
+	pVis->EndScene();
+	return true;
+}
+
+
+
+hydroc::gui::GUIImpl::MyActionReceiver::MyActionReceiver(bool& buttonPressed)
+			: pressed(buttonPressed) {
+
+}
+
+/// @brief Initialize Action with System
+/// @param vsys 
+void hydroc::gui::GUIImpl::MyActionReceiver::Init(chrono::irrlicht::ChVisualSystemIrrlicht* vsys) {
+    // store pointer application
+    vis = vsys;
+
+    // ..add a GUI button to control pause/play
+    pauseButton = vis->GetGUIEnvironment()->addButton(rect<s32>(510, 20, 650, 35));
+    buttonText = vis->GetGUIEnvironment()->addStaticText(L"Paused", rect<s32>(560, 20, 600, 35), false);
+}
+
+
+bool hydroc::gui::GUIImpl::MyActionReceiver::OnEvent(const irr::SEvent& event) {
+    // check if user clicked button
+    if (event.EventType == EEVENT_TYPE::EET_GUI_EVENT) {
+        switch (event.GUIEvent.EventType) {
+        case EGUI_EVENT_TYPE::EGET_BUTTON_CLICKED:
+            pressed = !pressed;
+            if (pressed) {
+                buttonText->setText(L"Playing");
+            }
+            else {
+                buttonText->setText(L"Paused");
+            }
+            return pressed;
+            break;
+        default:
+            break;
+        }
+    }
+    return false;
+}
+
+#else //HYDROCHRONO_HAVE_IRRLICHT	
+
+
+
+GUIImpl::GUIImpl()
+{
+
+}
+
+
+void GUIImpl::Init(UI& ui, chrono::ChSystem* system, const char* title)
+{
+	std::cout << "Warning: GUI deactivated. Compilation without Irrlicht library" << std::endl;
+}
+
+bool GUIImpl::IsRunning(double timestep) {
+	return true;
+}
+
+
+
+#endif // HYDROCHRONO_HAVE_IRRLICHT	
+
+
+//
+
+GUI::GUI():
+		pImpl(std::make_shared<hydroc::gui::GUIImpl>())
+{
+
+    simulationStarted = false; // Simulation is Paused
+
+}
+
+
+void GUI::Init(chrono::ChSystem* system, const char* title) 
+{
+	UI::Init(system, title);
+	pImpl->Init(*this, system, title);
+}
+
+bool GUI::IsRunning(double timestep) {
+
+	
+	if(pImpl->IsRunning(timestep) == false) return false;
+	
+	// If still running call the base class
+	return UI::IsRunning(timestep);
+}
+
+

--- a/src/gui/guihelper.cpp
+++ b/src/gui/guihelper.cpp
@@ -26,6 +26,9 @@ void UI::Init(chrono::ChSystem* system, const char* title)
 
 }
 
+void UI::SetCamera(double x, double y, double z, double dirx, double diry, double dirz) {
+}
+
 bool UI::IsRunning(double timestep) {
 
 
@@ -59,6 +62,7 @@ public:
 	GUIImpl& operator = (const GUIImpl&) = delete;
 
 	void Init(UI& ui, chrono::ChSystem*, const char* title);
+	void SetCamera(double x, double y, double z, double dirx, double diry, double dirz);
 	bool IsRunning(double timestep);
 private:
 #ifdef HYDROCHRONO_HAVE_IRRLICHT	
@@ -90,6 +94,7 @@ class hydroc::gui::GUIImpl::MyActionReceiver : public irr::IEventReceiver {
 		MyActionReceiver(bool& buttonPressed);
 		bool OnEvent(const irr::SEvent& event);
         void Init(chrono::irrlicht::ChVisualSystemIrrlicht* vsys);
+		void SetCamera(double x, double y, double z, double dirx, double diry, double dirz);
 	private:
 		chrono::irrlicht::ChVisualSystemIrrlicht* vis;
 		irr::gui::IGUIButton* pauseButton;
@@ -129,6 +134,10 @@ void GUIImpl::Init(UI& ui, chrono::ChSystem* system, const char* title)
 	pVis->AddSkyBox();
 	pVis->AddCamera(chrono::ChVector<>(8, -25, 15), chrono::ChVector<>(0, 0, 0));
 	pVis->AddTypicalLights();
+}
+
+void GUIImpl::SetCamera(double x, double y, double z, double dirx, double diry, double dirz) {
+	pVis->AddCamera({x, y, z}, {dirx, diry, dirz});
 }
 
 bool GUIImpl::IsRunning(double timestep) {
@@ -201,6 +210,9 @@ void GUIImpl::Init(UI& ui, chrono::ChSystem* system, const char* title)
 	std::cout << "Warning: GUI deactivated. Compilation without Irrlicht library" << std::endl;
 }
 
+void GUIImpl::SetCamera(double x, double y, double z, double dirx, double diry, double dirz) {
+}
+
 bool GUIImpl::IsRunning(double timestep) {
 	return true;
 }
@@ -225,6 +237,10 @@ void GUI::Init(chrono::ChSystem* system, const char* title)
 {
 	UI::Init(system, title);
 	pImpl->Init(*this, system, title);
+}
+
+void GUI::SetCamera(double x, double y, double z, double dirx, double diry, double dirz) {
+	pImpl->SetCamera(x, y, z, dirx, diry, dirz);
 }
 
 bool GUI::IsRunning(double timestep) {


### PR DESCRIPTION
Refactor irrlicht dependency for all demos files

New library HydroChronoGUI

Simpler main loop in demos.

Set All irrlicht dependencies in a private implementation file.
No more #ifdef HAVE_IRRLICHT outside of this file.

Should work even if chrono is compiled without irrlicht.

Provide an option in demos/main --nogui (2nd argument) to run the simulation without graphic window. 