### PR TITLE
Fix system-wide AM matrix for non-hydro bodies

### DIFF
--- a/include/hydroc/chloadaddedmass.h
+++ b/include/hydroc/chloadaddedmass.h
@@ -6,6 +6,7 @@
 #include <chrono/physics/ChBody.h>
 
 #include <chrono/physics/ChLoad.h>
+#include <chrono/physics/ChSystem.h>
 
 using namespace chrono;
 //using namespace chrono::fea;
@@ -14,8 +15,8 @@ using namespace chrono;
 class ChLoadAddedMass : public chrono::ChLoadCustomMultiple {
 public:
 	ChLoadAddedMass(const std::vector<H5FileInfo>& file,   ///< h5 file to initialize added mass with
-					std::vector<std::shared_ptr<ChLoadable>>& bodies  ///< objects to apply additional inertia to
-					);     
+		std::vector<std::shared_ptr<ChLoadable>>& bodies,  ///< objects to apply additional inertia to
+		ChSystem* system);
 //	/// "Virtual" copy constructor (covariant return type).
 	virtual ChLoadAddedMass* Clone() const override { return new ChLoadAddedMass(*this); }
 //
@@ -44,7 +45,8 @@ public:
 		const double c) override;       ///< a scaling factor
 
 private:
+	ChSystem* system;
 	ChMatrixDynamic<double> infinite_added_mass;       ///< added mass at infinite frequency in global coordinates
-	int nBodies;
+	ChMatrixDynamic<double> infinite_added_mass_system;      ///< added mass at infinite frequency in global coordinates (system matrix)
 	virtual bool IsStiff() override { return true; } // this to force the use of the inertial M, R and K matrices
 };

--- a/src/chloadaddedmass.cpp
+++ b/src/chloadaddedmass.cpp
@@ -13,14 +13,18 @@
  * initializes body to have load applied to and added mass matrix from h5 file object
  *******************************************************************************/
 ChLoadAddedMass::ChLoadAddedMass(const std::vector<H5FileInfo>& user_h5_body_data,
-                                 std::vector<std::shared_ptr<ChLoadable>>& bodies)
-    : ChLoadCustomMultiple(bodies) {
-	nBodies = bodies.size();
+	std::vector<std::shared_ptr<ChLoadable>>& bodies,
+	ChSystem* system)
+	: ChLoadCustomMultiple(bodies), system(system) {
+	auto nBodies = bodies.size();
 
 	infinite_added_mass.setZero(6 * nBodies, 6 * nBodies);
 	for (int i = 0; i < nBodies; i++) {
 		infinite_added_mass.block(i * 6, 0, 6, nBodies * 6) = user_h5_body_data[i].GetInfAddedMassMatrix();
 	}
+
+	// initialize added mass matrix for whole system
+	infinite_added_mass_system = infinite_added_mass;
 }
 
 /*******************************************************************************
@@ -34,8 +38,25 @@ void ChLoadAddedMass::ComputeJacobian(ChState* state_x,       ///< state positio
                                       ChMatrixRef mR,         ///< result dQ/dv
                                       ChMatrixRef mM          ///< result dQ/da
 ) {
-	// set mass matrix here
-	jacobians->M = infinite_added_mass;
+
+	// The following ensures that the added mass matrix matches the size of the ChSystem mass matrix. It is necessary
+	// for systems that have both hydro and non-hydro bodies when adding a system-wide load.
+	// @todo if possible, remove hack by using initialiazer function called AFTER the ChSystem is assembled.
+	// get mass matrix size
+	ChSparseMatrix mm;
+	system->GetMassMatrix(&mm);
+	auto mmrows = mm.rows();
+	// check if ChSystem mass matrix size different from added mass matrix size
+	if (mmrows != infinite_added_mass_system.rows() && mmrows > 0) {
+		// initialize/update system matrix;
+		infinite_added_mass_system.setZero(mmrows, mmrows);
+		auto amrows = infinite_added_mass.rows();
+		infinite_added_mass_system.block(0, 0, amrows, amrows) = infinite_added_mass;
+	}
+
+
+	//set mass matrix here
+	jacobians->M = infinite_added_mass_system;
 
 	// R gyroscopic damping matrix terms (6Nx6N)
 	// 0 for added mass

--- a/src/hydro_forces.cpp
+++ b/src/hydro_forces.cpp
@@ -261,7 +261,7 @@ TestHydro::TestHydro(std::vector<std::shared_ptr<ChBody>> user_bodies, std::stri
 	std::vector<std::shared_ptr<ChLoadable>> loadables(bodies.size());
 	for (auto i = 0; i < bodies.size(); ++i) { loadables[i] = bodies[i]; }
 
-	my_loadbodyinertia = chrono_types::make_shared<ChLoadAddedMass>(file_info, loadables);
+	my_loadbodyinertia = chrono_types::make_shared<ChLoadAddedMass>(file_info, loadables, bodies[0]->GetSystem());
 	bodies[0]->GetSystem()->Add(my_loadcontainer);
 	my_loadcontainer->Add(my_loadbodyinertia);
 


### PR DESCRIPTION
This PR fixes an issue that happens when mixing hydro and non-hydro bodies in the system.

The system-wide custom load was applied with an added-mass matrix with a size depending only on hydro bodies but the system expected a load matrix of the same size as the system mass matrix (i.e. including non-hydro bodies), leading to a crash when non-hydro bodies where included in the system. Current demos/examples do not include non-hydro bodies (so the issue would not happen).

The current fix is a "hack" where the system added mass matrix size is verified against the system mass matrix, and is adjusted only if the sizes do not match (should happen only once during simulation). It is assumed that all hydro bodies are defined before the other bodies (hydro bodies added mass values are added in the upper left part of the system-wide matrix). Ideally, this should be done only once after initializing the system (could not identify a function called only once after setup of the system for the custom load).