### PR TITLE
Fix performance issue for large systems

### DIFF
--- a/src/chloadaddedmass.cpp
+++ b/src/chloadaddedmass.cpp
@@ -41,28 +41,27 @@ void ChLoadAddedMass::ComputeJacobian(ChState* state_x,       ///< state positio
     // The following ensures that the added mass matrix matches the size of the ChSystem mass matrix. It is necessary
     // for systems that have both hydro and non-hydro bodies when adding a system-wide load.
     // @todo if possible, remove hack by using initialiazer function called AFTER the ChSystem is assembled.
+
     // get mass matrix size
-    ChSparseMatrix mm;
-    system->GetMassMatrix(&mm);
-    auto mmrows = mm.rows();
+    auto mmrows = system->GetNcoords_w();  // number of rows in system mass matrix
     // check if ChSystem mass matrix size different from added mass matrix size
     if (mmrows != infinite_added_mass_system.rows() && mmrows > 0) {
         // initialize/update system matrix;
         infinite_added_mass_system.setZero(mmrows, mmrows);
         auto amrows                                            = infinite_added_mass.rows();
         infinite_added_mass_system.block(0, 0, amrows, amrows) = infinite_added_mass;
+
+        // set mass matrix here
+        jacobians->M = infinite_added_mass_system;
+
+        // R gyroscopic damping matrix terms (6Nx6N)
+        // 0 for added mass
+        jacobians->R.setZero();
+
+        // K inertial stiffness matrix terms (6Nx6N)
+        // 0 for added mass
+        jacobians->K.setZero();
     }
-
-    // set mass matrix here
-    jacobians->M = infinite_added_mass_system;
-
-    // R gyroscopic damping matrix terms (6Nx6N)
-    // 0 for added mass
-    jacobians->R.setZero();
-
-    // K inertial stiffness matrix terms (6Nx6N)
-    // 0 for added mass
-    jacobians->K.setZero();
 }
 
 /*******************************************************************************


### PR DESCRIPTION
This PR fixes the performance issues on large systems:
- get number of rows of mass matrix more efficiently
- populate mass matrix only once (or everytime the matrix size changes)

Tested on a problem with a system mass matrix of size ~1000x1000 with one hydro body (the rest non-hydro) and with irrlicht visualization: it was 6.15 times faster than before this PR (done for 100s of simulated time).